### PR TITLE
Abstract summary fcn test into script

### DIFF
--- a/test_measurement_sets.py
+++ b/test_measurement_sets.py
@@ -1,0 +1,20 @@
+
+import casatools
+import measurement_sets
+import sys
+
+msmd = casatools.msmetadata()
+
+#data_path = "dataReduction/TS8004_C_001_20190801/TS8004_C_001_20190801_avg.ms"
+data_path = sys.argv[1]
+print("Path:", data_path)
+
+# Populate key summary to test function
+
+subset_keys_vals = measurement_sets.summary_metadata(data_path)
+
+for each_key in subset_keys_vals:
+	print(each_key)
+
+# Check against what is contained in actual dictionary, because for loop is only printing the headers it seems, not sure how to extract values at the minute, so no way to parse them.
+# print(subset_keys_vals)


### PR DESCRIPTION
Added a "test" script to test the summary_metadata function since measurement_sets.py script contains no actual function calls and thus looked more like a module to me.  
file path is passed in at command line call of test_measurement_sets.py so that wherever you have the local data set works for this test for now.  
Script prints the expected metadata summary keys. 
